### PR TITLE
fix: Remove Arweave JWK logging

### DIFF
--- a/src/utils/check.ts
+++ b/src/utils/check.ts
@@ -40,7 +40,6 @@ export const checkParams = (params: Record<string, unknown>): void => {
 }
 
 export const checkSignConfig = (accountType: ChainType, config: Config): void => {
-  console.log(accountType, config)
   if (config.isSmartAccount ?? false) {
     checkItem('account', config.account)
   } else if (accountType === ChainType.ethereum) {


### PR DESCRIPTION
## Summary

This PR removes the `console.log` which prints out sensitive information like Arweave JWK.

We could however silent all the `console.log` while using `everpay-js` overriding `console.log` using:
```ts
// Silence console.log
const originalLog = console.log;
console.log = () => {};

// everpay-js related code

// Restore console log
console.log = originalLog;
```